### PR TITLE
Recreate .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Google Generative AI API Key
+GEMINI_API_KEY=YOUR_GEMINI_API_KEY
+
+# PostgreSQL Database Configuration
+# If these are not set or left as default, the application will fall back to using a local SQLite database (quotes_fallback.db).
+DB_USER=your_db_user
+DB_PASSWORD=your_db_password
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=quotes_db


### PR DESCRIPTION
This commit recreates the .env.example file.
It includes placeholders for the GEMINI_API_KEY and PostgreSQL database credentials (DB_USER, DB_PASSWORD, DB_HOST, DB_PORT, DB_NAME). Comments are included to explain each variable and the fallback behavior to SQLite if database variables are not set.