### PR TITLE
Here's the fix I've made to your code:

### DIFF
--- a/prompts.py
+++ b/prompts.py
@@ -57,13 +57,14 @@ except Exception as e:
 
 
 # Main system prompt or instruction for the LLM
+ESCAPED_OUTPUT_SCHEMA_DESCRIPTION = OUTPUT_SCHEMA_DESCRIPTION.replace("{", "{{").replace("}", "}}")
 QUOTE_EXTRACTION_PROMPT_TEMPLATE = f"""You are an expert assistant specialized in analyzing texts and extracting significant quotes, sayings, or "hadith" (which in a general sense means a saying or account).
 Your task is to carefully read the provided text chunk from an ebook and identify any such notable statements or sayings.
 
 For each quote you identify, you MUST provide the information in a structured JSON format, as a list of JSON objects.
 Each object in the list MUST conform to the following JSON schema, detailing the expected fields:
 ```json
-{OUTPUT_SCHEMA_DESCRIPTION}
+{ESCAPED_OUTPUT_SCHEMA_DESCRIPTION}
 ```
 
 Key instructions for extraction:


### PR DESCRIPTION
I've addressed an issue where the QUOTE_EXTRACTION_PROMPT_TEMPLATE was causing a KeyError (for example, KeyError: '\n "quote_text"'). This was happening because curly braces within the OUTPUT_SCHEMA_DESCRIPTION (which is the JSON schema string) were being incorrectly understood as format placeholders when the .format(text_chunk=...) function was called in get_formatted_quote_extraction_prompt.

To resolve this, I've explicitly escaped the curly braces in OUTPUT_SCHEMA_DESCRIPTION. This means I've changed { to {{ and } to }} before it's used in the main f-string definition of QUOTE_EXTRACTION_PROMPT_TEMPLATE.

Now, when QUOTE_EXTRACTION_PROMPT_TEMPLATE is processed by .format(text_chunk=...), these escaped {{ and }} pairs are correctly turned back into single literal { and } characters. This makes sure the JSON schema is displayed as it should be, without creating any unintended placeholders. The only placeholder that .format() will now process is {text_chunk}, just as it was originally meant to.