### PR TITLE
Fix: Robustly escape schema and example JSON in prompt template

### DIFF
--- a/prompts.py
+++ b/prompts.py
@@ -57,6 +57,17 @@ except Exception as e:
 # Define ESCAPED_OUTPUT_SCHEMA_DESCRIPTION immediately after OUTPUT_SCHEMA_DESCRIPTION is finalized
 ESCAPED_OUTPUT_SCHEMA_DESCRIPTION = OUTPUT_SCHEMA_DESCRIPTION.replace("{", "{{").replace("}", "}}")
 
+EXAMPLE_JSON_CONTENT = """[
+  {  # Start of example JSON object
+    "quote_text": "The best way to predict the future is to create it.",
+    "speaker": "Peter Drucker",
+    "context": "Discussing proactive approaches to business strategy and innovation.",
+    "topic": "Future and Creation",
+    "additional_info": "Often attributed to Peter Drucker, emphasizing agency."
+  }
+]"""
+ESCAPED_EXAMPLE_JSON_CONTENT = EXAMPLE_JSON_CONTENT.replace("{", "{{").replace("}", "}}")
+
 # Define QUOTE_EXTRACTION_PROMPT_TEMPLATE using the escaped version
 QUOTE_EXTRACTION_PROMPT_TEMPLATE = f"""You are an expert assistant specialized in analyzing texts and extracting significant quotes, sayings, or "hadith" (which in a general sense means a saying or account).
 Your task is to carefully read the provided text chunk from an ebook and identify any such notable statements or sayings.
@@ -93,15 +104,7 @@ Text chunk to analyze:
 
 Example of a valid response with one quote:
 ```json
-[
-  {{  # Start of example JSON object
-    "quote_text": "The best way to predict the future is to create it.",
-    "speaker": "Peter Drucker",
-    "context": "Discussing proactive approaches to business strategy and innovation.",
-    "topic": "Future and Creation",
-    "additional_info": "Often attributed to Peter Drucker, emphasizing agency."
-  }}  # End of example JSON object
-]
+{ESCAPED_EXAMPLE_JSON_CONTENT}
 ```
 
 Example of a valid response with no quotes:


### PR DESCRIPTION
This commit further refines the solution to prevent KeyErrors during prompt formatting. The error, in its latest form
(e.g., KeyError: '  # Start of example JSON object\n    "quote_text"'),
indicated that the example JSON block, including comments, was being
misinterpreted as a format placeholder.

This fix implements the following:
1. The main schema description (`OUTPUT_SCHEMA_DESCRIPTION`) continues to be escaped (braces doubled) into `ESCAPED_OUTPUT_SCHEMA_DESCRIPTION` and used as such in the `QUOTE_EXTRACTION_PROMPT_TEMPLATE` f-string.
2. The multi-line example JSON, previously hardcoded with `{{ }}` within the main f-string, is now defined as a separate string variable (`EXAMPLE_JSON_CONTENT`).
3. This `EXAMPLE_JSON_CONTENT` is then escaped (braces doubled) into `ESCAPED_EXAMPLE_JSON_CONTENT`.
4. `QUOTE_EXTRACTION_PROMPT_TEMPLATE` now uses `{ESCAPED_EXAMPLE_JSON_CONTENT}` to insert the example JSON.
5. The `{{text_chunk}}` placeholder remains for the actual text input.

By pre-escaping both the main schema and the entire example JSON block before their inclusion in the main f-string, all their internal curly braces will be correctly rendered as literal characters during the final `.format(text_chunk=...)` call. This should robustly prevent any part of the schema or example from being treated as an unintended placeholder, definitively resolving the KeyError.