### PR TITLE
feat: Enhance quote extraction with language and content rules

### DIFF
--- a/main.py
+++ b/main.py
@@ -111,6 +111,12 @@ def main():
                             print(f"    Warning: LLM returned a non-dictionary item in its list: {quote_data_from_llm}. Skipping this item.")
                             continue
                         try:
+                            # Handle additional_info: if it's a dict, convert to JSON string
+                            # This ensures compatibility with QuoteLLM which expects a string that is JSON.
+                            ai = quote_data_from_llm.get("additional_info")
+                            if isinstance(ai, dict):
+                                quote_data_from_llm["additional_info"] = json.dumps(ai, ensure_ascii=False)
+
                             # Validate data against Pydantic model (QuoteLLM)
                             validated_quote = QuoteLLM(**quote_data_from_llm)
 

--- a/prompts.py
+++ b/prompts.py
@@ -28,26 +28,26 @@ except Exception as e:
     # Fallback manual schema description, ensure 2-space indent
     OUTPUT_SCHEMA_DESCRIPTION = '''{
       "quote_text": {
-        "description": "The exact text of the saying or quote.",
+        "description": "The exact text of the saying or quote. This text MUST NOT be translated from its original language.",
         "type": "str"
       },
       "speaker": {
-        "description": "The person or character who uttered the saying. If unknown, can be null or 'Unknown'.",
+        "description": "The person or character who uttered the saying. If unknown, can be null or 'Unknown'. This field MUST be in Farsi.",
         "type": "str",
         "default": "None"
       },
       "context": {
-        "description": "The immediate context surrounding the quote, helping to understand its meaning. This should be a brief summary of the situation or surrounding text.",
+        "description": "The immediate context surrounding the quote, helping to understand its meaning. This should be a brief summary of the situation or surrounding text. This field MUST be in Farsi.",
         "type": "str",
         "default": "None"
       },
       "topic": {
-        "description": "The main topic or theme of the quote (e.g., 'Patience', 'Knowledge', 'Charity'). If multiple, pick the most prominent or list them.",
+        "description": "The main topic or theme of the quote (e.g., 'Patience', 'Knowledge', 'Charity'). If multiple, pick the most prominent or list them. This field MUST be in Farsi.",
         "type": "str",
         "default": "None"
       },
       "additional_info": {
-        "description": "Any other relevant information, such as specific circumstances, historical relevance, or if it's a direct response to a question. If none, can be null.",
+        "description": "A JSON string containing other relevant information. This string MUST include a 'surah' key with the Surah name in Farsi. If the 'quote_text' is in Arabic, this JSON string MUST also include a 'quote_translation' key with the Farsi translation of the quote. Example for an Arabic quote: \\"{\\\\\\"surah\\\\\\": \\\\\\"سورة الفاتحة\\\\\\", \\\\\\"quote_translation\\\\\\": \\\\\\"به نام خداوند بخشنده مهربان\\\\\\"}\\". Example for a Farsi quote: \\"{\\\\\\"surah\\\\\\": \\\\\\"سوره بقره\\\\\\"}\\". This entire field MUST be in Farsi, except for the JSON structure itself.",
         "type": "str",
         "default": "None"
       }
@@ -58,12 +58,19 @@ except Exception as e:
 ESCAPED_OUTPUT_SCHEMA_DESCRIPTION = OUTPUT_SCHEMA_DESCRIPTION.replace("{", "{{").replace("}", "}}")
 
 EXAMPLE_JSON_CONTENT = """[
-  {  # Start of example JSON object
-    "quote_text": "The best way to predict the future is to create it.",
-    "speaker": "Peter Drucker",
-    "context": "Discussing proactive approaches to business strategy and innovation.",
-    "topic": "Future and Creation",
-    "additional_info": "Often attributed to Peter Drucker, emphasizing agency."
+  {
+    "quote_text": "بسم الله الرحمن الرحيم",
+    "speaker": "النبي محمد (ص)",
+    "context": "سياق المثال",
+    "topic": "الموضوع",
+    "additional_info": "{\\"surah\\": \\"سورة الفاتحة\\", \\"quote_translation\\": \\"به نام خداوند بخشنده مهربان\\"}"
+  },
+  {
+    "quote_text": "این یک نقل قول فارسی است",
+    "speaker": "سخنران فرضی",
+    "context": "زمینه نمونه",
+    "topic": "موضوع نمونه",
+    "additional_info": "{\\"surah\\": \\"سوره بقره\\"}"
   }
 ]"""
 ESCAPED_EXAMPLE_JSON_CONTENT = EXAMPLE_JSON_CONTENT.replace("{", "{{").replace("}", "}}")
@@ -79,11 +86,11 @@ Each object in the list MUST conform to the following JSON schema, detailing the
 ```
 
 Key instructions for extraction:
-1.  **`quote_text`**: This MUST be the verbatim text of the saying or statement. Do not paraphrase.
-2.  **`speaker`**: Identify who made the statement. If explicitly mentioned (e.g., "John said...", "...replied Mary"), use that name. If implied by context, use the name. If it's general narration or the speaker is truly unknown, use "Unknown" or "Narrator" as appropriate. If the text indicates a source (e.g. "a wise man once said"), use that.
-3.  **`context`**: Briefly describe the situation in which the quote was made. What was happening, being discussed, or what led to the statement?
-4.  **`topic`**: Provide a concise keyword or short phrase for the main theme or subject of the quote (e.g., "Wisdom", "Courage", "On Patience", "The nature of good deeds").
-5.  **`additional_info`**: Include any other relevant details. For instance, was it a response to a question? Was it directed at a specific person or group? Is there a specific cultural or historical nuance mentioned? If none, this field can be omitted or null.
+1.  **`quote_text`**: This MUST be the verbatim text of the saying or statement. Do NOT translate the `quote_text`.
+2.  **`speaker`**: Identify who made the statement. This field MUST be in Farsi. If explicitly mentioned (e.g., "John said...", "...replied Mary"), use that name. If implied by context, use the name. If it's general narration or the speaker is truly unknown, use "Unknown" or "Narrator" as appropriate (in Farsi, e.g., "ناشناس" یا "راوی"). If the text indicates a source (e.g. "a wise man once said"), use that (in Farsi).
+3.  **`context`**: Briefly describe the situation in which the quote was made. What was happening, being discussed, or what led to the statement? This field MUST be in Farsi.
+4.  **`topic`**: Provide a concise keyword or short phrase for the main theme or subject of the quote (e.g., "صبر", "دانش", "صدقه"). This field MUST be in Farsi.
+5.  **`additional_info`**: This field MUST be a JSON string. It must include a 'surah' key with the Surah name in Farsi (e.g., "سوره فاتحه"). If the `quote_text` is in Arabic, the JSON string MUST also include a 'quote_translation' key with the Farsi translation of the `quote_text`. For example, if `quote_text` is "بسم الله الرحمن الرحيم", `additional_info` would be "{{\\"surah\\": \\"سورة الفاتحة\\", \\"quote_translation\\": \\"به نام خداوند بخشنده مهربان\\"}}". If `quote_text` is already in Farsi, `additional_info` would be "{{\\"surah\\": \\"سوره بقره\\"}}". All text values within the JSON string (like Surah name and translation) MUST be in Farsi.
 
 Output Requirements:
 - Your entire response MUST be a single JSON list.
@@ -102,7 +109,7 @@ Text chunk to analyze:
 {{text_chunk}}
 -----------------------------------
 
-Example of a valid response with one quote:
+Example of a valid response with quotes:
 ```json
 {ESCAPED_EXAMPLE_JSON_CONTENT}
 ```
@@ -149,5 +156,3 @@ if __name__ == '__main__':
         print("Could not import QuoteLLM from .schemas. Ensure schemas.py is in the same directory (or package structure is correct) and there are no circular imports.")
     except Exception as e:
         print(f"An error occurred while accessing QuoteLLM schema: {e}")
-
-

--- a/schemas.py
+++ b/schemas.py
@@ -11,7 +11,7 @@ class QuoteLLM(BaseModel):
     speaker: Optional[str] = Field(None, description="The person or character who uttered the saying. If unknown, can be null.")
     context: Optional[str] = Field(None, description="The immediate context surrounding the quote, helping to understand its meaning.")
     topic: Optional[str] = Field(None, description="The main topic or theme of the quote.")
-    additional_info: Optional[str] = Field(None, description="Any other relevant information about the quote or its source.")
+    additional_info: Optional[str] = Field(None, description="A JSON string containing other relevant information. Expected keys include 'surah' (the name of the Surah in Farsi) and, if the quote_text is in Arabic, 'quote_translation' (the Farsi translation of the quote). Example: '{\\"surah\\": \\"سورة الفاتحة\\", \\"quote_translation\\": \\"به نام خداوند بخشنده مهربان\\"}'")
 
     model_config = {
         "json_schema_extra": {

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,128 @@
+import json
+import unittest
+from unittest.mock import patch, MagicMock
+import sys
+from pathlib import Path
+
+# Add project root to sys.path to allow direct imports of project modules
+project_root = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(project_root))
+
+# Now import main function or specific components from main.py
+# Assuming main.py has a callable main_function or similar
+try:
+    from main import main as main_function
+except ImportError:
+    # This is a fallback or error for the testing environment if main cannot be imported.
+    # The test execution might fail if main_function is not available.
+    print("Error: Could not import main_function from main.py. Ensure main.py is structured to allow this.")
+    print(f"Current sys.path: {sys.path}")
+    print(f"Project root determined as: {project_root}")
+    main_function = None # Define it as None to avoid runtime errors in test class if import fails
+
+from schemas import QuoteLLM
+
+# Target for patching in main.py
+LLM_HANDLER_ANALYZE_TEXT_PATH = "main.analyze_text_with_gemini"
+DATABASE_SAVE_QUOTES_PATH = "main.save_quotes_to_db"
+MAIN_GET_DB_PATH = "main.get_db"
+EPUB_PARSER_EXTRACT_PATH = "main.extract_text_from_epub"
+EPUB_PARSER_CHUNK_PATH = "main.chunk_text"
+MAIN_CREATE_DB_AND_TABLES_PATH = "main.create_db_and_tables"
+
+
+class TestMainProcessing(unittest.TestCase):
+
+    @patch(MAIN_CREATE_DB_AND_TABLES_PATH, MagicMock()) # Mock db creation
+    @patch(EPUB_PARSER_CHUNK_PATH, MagicMock(return_value=[{'source': 'Test Source', 'text': 'Test Text'}]))
+    @patch(EPUB_PARSER_EXTRACT_PATH, MagicMock(return_value=[{'source': 'Test Source', 'text': 'Test Text'}]))
+    @patch(DATABASE_SAVE_QUOTES_PATH)
+    @patch(LLM_HANDLER_ANALYZE_TEXT_PATH)
+    @patch(MAIN_GET_DB_PATH)
+    def test_additional_info_processing_and_structure(
+        self, mock_get_db, mock_analyze_text, mock_save_quotes,
+        mock_epub_extract, mock_epub_chunk, mock_db_create # Order matters for mock args
+    ):
+        if main_function is None:
+            self.skipTest("Skipping test as main_function could not be imported.")
+
+        mock_db_session = MagicMock()
+        mock_get_db.return_value = iter([mock_db_session]) # Simulate generator behavior
+
+        mock_llm_response = [
+            {
+                "quote_text": "هذا نص عربي", # Arabic quote
+                "speaker": "المتحدث", # Farsi as per prompt (example)
+                "context": "سياق باللغة الفارسية", # Farsi
+                "topic": "موضوع باللغة الفارسية", # Farsi
+                "additional_info": { # Will be converted to JSON string by main.py
+                    "surah": "سورة الفاتحة", # Farsi
+                    "quote_translation": "این ترجمه فارسی است" # Farsi translation of Arabic quote
+                }
+            },
+            {
+                "quote_text": "این یک نقل قول فارسی است", # Farsi quote
+                "speaker": "سخنران فرضی", # Farsi
+                "context": "زمینه نمونه", # Farsi
+                "topic": "موضوع نمونه", # Farsi
+                "additional_info": '{"surah": "سوره بقره"}' # Already a JSON string, Farsi surah
+            },
+            {
+                "quote_text": "نقل قول سوم بدون اطلاعات اضافی", # Farsi quote
+                "speaker": "ناشناس", # Farsi
+                "context": "بدون زمینه خاص", # Farsi
+                "topic": "عمومی", # Farsi
+                "additional_info": None # No additional info
+            }
+        ]
+        mock_analyze_text.return_value = mock_llm_response
+
+        # This list will capture the data passed to save_quotes_to_db
+        saved_quotes_capture = []
+        def mock_save_quotes_impl(db, quotes_list_dicts):
+            # main.py calls quote.model_dump() before appending to batch,
+            # so quotes_list_dicts here should be a list of dictionaries.
+            saved_quotes_capture.extend(quotes_list_dicts)
+            return len(quotes_list_dicts) # Simulate returning number of saved items
+        mock_save_quotes.side_effect = mock_save_quotes_impl
+
+        # Mock command line arguments for main_function
+        with patch('argparse.ArgumentParser') as mock_arg_parser:
+            mock_args = MagicMock()
+            mock_args.epub_filepath = "dummy.epub" # Needs to be a string
+            mock_args.max_chunk_size = 1000
+            mock_args.batch_size = 10 # Ensure all mocked quotes are processed in one batch
+            mock_arg_parser.return_value.parse_args.return_value = mock_args
+
+            main_function() # Call the main processing function
+
+        # Assertions
+        self.assertEqual(mock_analyze_text.call_count, 1, "LLM should be called once for the single chunk.")
+        self.assertEqual(mock_save_quotes.call_count, 1, "Save to DB should be called once for the batch.")
+        self.assertEqual(len(saved_quotes_capture), 3, "Should have processed all three mocked quotes.")
+
+        # Detailed check for the first quote (Arabic quote_text, additional_info as dict from LLM)
+        quote1_saved = saved_quotes_capture[0]
+        self.assertEqual(quote1_saved['quote_text'], "هذا نص عربي", "quote_text should remain untranslated.")
+        self.assertEqual(quote1_saved['speaker'], "المتحدث") # Assuming speaker is passed as is
+
+        # Verify additional_info was converted to a JSON string and its content
+        self.assertIsInstance(quote1_saved['additional_info'], str, "additional_info should be a string in the saved data.")
+        expected_ai1_dict = {"surah": "سورة الفاتحة", "quote_translation": "این ترجمه فارسی است"}
+        self.assertDictEqual(json.loads(quote1_saved['additional_info']), expected_ai1_dict, "Content of additional_info JSON string is incorrect.")
+        self.assertEqual(quote1_saved['epub_source_identifier'], 'Test Source', "Source identifier should be set.")
+
+        # Detailed check for the second quote (Farsi quote_text, additional_info as string from LLM)
+        quote2_saved = saved_quotes_capture[1]
+        self.assertEqual(quote2_saved['quote_text'], "این یک نقل قول فارسی است")
+        self.assertIsInstance(quote2_saved['additional_info'], str, "additional_info should be a string.")
+        expected_ai2_dict = {"surah": "سوره بقره"} # Only surah for Farsi quotes
+        self.assertDictEqual(json.loads(quote2_saved['additional_info']), expected_ai2_dict)
+
+        # Detailed check for the third quote (additional_info as None)
+        quote3_saved = saved_quotes_capture[2]
+        self.assertEqual(quote3_saved['quote_text'], "نقل قول سوم بدون اطلاعات اضافی")
+        self.assertIsNone(quote3_saved['additional_info'], "additional_info should be None.")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit implements several enhancements to the quote extraction process:

1.  **Language Requirements:**
    - I've updated `prompts.py` to instruct that the `speaker` field must be in Farsi or Arabic.
    - `context`, `topic`, and the content of `additional_info` must be in Farsi.

2.  **`additional_info` Enhancements:**
    - The `additional_info` field is now structured as a JSON string.
    - It must include the related Surah (سوره) of the quotation/hadith.
    - If `quote_text` is in Arabic, its Farsi translation is stored in `additional_info` under the key "quote_translation".
    - I've updated `schemas.py` to document this JSON string format for `additional_info`.
    - `main.py` now ensures that `additional_info` is converted to a JSON string if it's returned as a dictionary, before validation.

3.  **`quote_text` Integrity:**
    - I've instructed the system not to translate the `quote_text`, preserving its original form.

4.  **`epub_source_identifier`:**
    - The requirement to include page numbers was deemed complex with the current EPUB parsing capabilities and has been deferred. The identifier will continue to use section IDs/titles.

5.  **Unit Tests:**
    - I've added new unit tests in `tests/test_main.py` to verify the correct processing of `additional_info` (including its conversion to a JSON string) and to ensure the data structure aligns with the new requirements.

These changes aim to improve the accuracy, consistency, and richness of the extracted quote data, particularly for Farsi and Arabic texts.