### PR TITLE
Fix: Modify prompt template construction to resolve KeyError

### DIFF
--- a/prompts.py
+++ b/prompts.py
@@ -75,14 +75,16 @@ EXAMPLE_JSON_CONTENT = """[
 ]"""
 ESCAPED_EXAMPLE_JSON_CONTENT = EXAMPLE_JSON_CONTENT.replace("{", "{{").replace("}", "}}")
 
-# Define QUOTE_EXTRACTION_PROMPT_TEMPLATE using the escaped version
-QUOTE_EXTRACTION_PROMPT_TEMPLATE = f"""You are an expert assistant specialized in analyzing texts and extracting significant quotes, sayings, or "hadith" (which in a general sense means a saying or account).
+# Define QUOTE_EXTRACTION_PROMPT_TEMPLATE parts
+PART1 = """You are an expert assistant specialized in analyzing texts and extracting significant quotes, sayings, or "hadith" (which in a general sense means a saying or account).
 Your task is to carefully read the provided text chunk from an ebook and identify any such notable statements or sayings.
 
 For each quote you identify, you MUST provide the information in a structured JSON format, as a list of JSON objects.
 Each object in the list MUST conform to the following JSON schema, detailing the expected fields:
 ```json
-{ESCAPED_OUTPUT_SCHEMA_DESCRIPTION}
+"""
+
+PART2 = """
 ```
 
 Key instructions for extraction:
@@ -90,7 +92,7 @@ Key instructions for extraction:
 2.  **`speaker`**: Identify who made the statement. This field MUST be in Farsi. If explicitly mentioned (e.g., "John said...", "...replied Mary"), use that name. If implied by context, use the name. If it's general narration or the speaker is truly unknown, use "Unknown" or "Narrator" as appropriate (in Farsi, e.g., "ناشناس" یا "راوی"). If the text indicates a source (e.g. "a wise man once said"), use that (in Farsi).
 3.  **`context`**: Briefly describe the situation in which the quote was made. What was happening, being discussed, or what led to the statement? This field MUST be in Farsi.
 4.  **`topic`**: Provide a concise keyword or short phrase for the main theme or subject of the quote (e.g., "صبر", "دانش", "صدقه"). This field MUST be in Farsi.
-5.  **`additional_info`**: This field MUST be a JSON string. It must include a 'surah' key with the Surah name in Farsi (e.g., "سوره فاتحه"). If the `quote_text` is in Arabic, the JSON string MUST also include a 'quote_translation' key with the Farsi translation of the `quote_text`. For example, if `quote_text` is "بسم الله الرحمن الرحيم", `additional_info` would be "{{\"surah\": \"سورة الفاتحة\", \"quote_translation\": \"به نام خداوند بخشنده مهربان\"}}". If `quote_text` is already in Farsi, `additional_info` would be "{{\"surah\": \"سوره بقره\"}}". All text values within the JSON string (like Surah name and translation) MUST be in Farsi.
+5.  **`additional_info`**: This field MUST be a JSON string. It must include a 'surah' key with the Surah name in Farsi (e.g., "سوره فاتحه"). If the `quote_text` is in Arabic, the JSON string MUST also include a 'quote_translation' key with the Farsi translation of the `quote_text`. For example, if `quote_text` is "بسم الله الرحمن الرحيم", `additional_info` would be "{\\"surah\\": \\"سورة الفاتحة\\", \\"quote_translation\\": \\"به نام خداوند بخشنده مهربان\\"}". If `quote_text` is already in Farsi, `additional_info` would be "{\\"surah\\": \\"سوره بقره\\"}". All text values within the JSON string (like Surah name and translation) MUST be in Farsi.
 
 Output Requirements:
 - Your entire response MUST be a single JSON list.
@@ -106,12 +108,16 @@ Consider the following when identifying quotes:
 
 Text chunk to analyze:
 -----------------------------------
-{{text_chunk}}
+"""
+
+PART3 = """
 -----------------------------------
 
 Example of a valid response with quotes:
 ```json
-{ESCAPED_EXAMPLE_JSON_CONTENT}
+"""
+
+PART4 = """
 ```
 
 Example of a valid response with no quotes:
@@ -121,6 +127,17 @@ Example of a valid response with no quotes:
 
 Now, please process the text chunk provided above and return the JSON list.
 """
+
+# Construct QUOTE_EXTRACTION_PROMPT_TEMPLATE by concatenating parts
+QUOTE_EXTRACTION_PROMPT_TEMPLATE = (
+    PART1
+    + ESCAPED_OUTPUT_SCHEMA_DESCRIPTION
+    + PART2
+    + "{text_chunk}"  # Direct placeholder for .format()
+    + PART3
+    + ESCAPED_EXAMPLE_JSON_CONTENT
+    + PART4
+)
 
 # Function to format the prompt with the text chunk
 def get_formatted_quote_extraction_prompt(text_chunk: str) -> str:


### PR DESCRIPTION
Reconstructs QUOTE_EXTRACTION_PROMPT_TEMPLATE in prompts.py by concatenating string parts rather than using a single large f-string. This change aims to prevent potential complex f-string evaluation issues that could lead to a KeyError when the template is formatted.

The schema and example JSON content (ESCAPED_OUTPUT_SCHEMA_DESCRIPTION and ESCAPED_EXAMPLE_JSON_CONTENT) are interpolated as string literals, and '{text_chunk}' is used as a direct placeholder for the .format() method.